### PR TITLE
feat: add digital vibrance control for NVIDIA displays

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "QOL-Scripts"
-version = "1.4.8"
+version = "1.5.0"
 description = "Quality of Life scripts for Windows"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/app.py
+++ b/src/app.py
@@ -16,9 +16,6 @@ from packaging import version as pkg_version
 import requests
 import pystray
 from PIL import Image
-from win32_window_monitor import (
-    init_com, set_win_event_hook, get_window_title, HookEvent
-)
 import ctypes
 from ctypes import wintypes
 import winshell
@@ -26,25 +23,12 @@ from win32com.client import Dispatch
 
 from settings import Settings, PROGRAM_NAME
 
-
-def _run_message_loop():
-    """Run WIN32 message loop until WM_QUIT is received.
-
-    Workaround for win32-window-monitor bug using TranslateMessageW
-    which doesn't exist (should be TranslateMessage).
-    """
-    user32 = ctypes.windll.user32
-    msg = wintypes.MSG()
-    while user32.GetMessageW(ctypes.byref(msg), 0, 0, 0) != 0:
-        user32.TranslateMessage(ctypes.byref(msg))
-        user32.DispatchMessageW(ctypes.byref(msg))
-
-
 from brightness import (
-    set_brightness_side_monitors, get_all_monitor_serials_except_focused,
-    clean_window_title, init_monitors_cache, get_all_monitor_serials
+    set_brightness_side_monitors, init_monitors_cache, get_all_monitor_serials,
+    BrightnessFocusConsumer
 )
-from vibrance import init_nvapi, set_vibrance
+from vibrance import init_nvapi, set_vibrance, VibranceFocusConsumer
+from focus_monitor import FocusMonitor
 from lol import LoLAutoAccept, LoLAutoPick, SharedLCUConnector
 from cs2 import CS2AutoAccept, CS2ConsoleWatcher
 from settings_window import SettingsWindow
@@ -126,7 +110,6 @@ class QOLApp:
         self.startup_shortcut = os.path.join(winshell.startup(), f"{PROGRAM_NAME}.lnk")
         signal.signal(signal.SIGINT, self.signal_handler)
         signal.signal(signal.SIGTERM, self.signal_handler)
-        self.last_focused_window = None
 
         # Create shared LCU connector with handlers
         self.lol_auto_accept = LoLAutoAccept(self.settings)
@@ -143,9 +126,15 @@ class QOLApp:
         self.cs2_watcher.register_callback(self.cs2_auto_accept.on_match_found)
         self.cs2_watcher.register_condebug_missing_callback(self._on_condebug_missing)
 
+        # Shared focus monitor: one daemon publishes the focused window;
+        # each feature has its own consumer thread that subscribes and reacts
+        # independently.
+        self.focus_monitor = FocusMonitor()
+        self.brightness_consumer = BrightnessFocusConsumer(self.settings, self.focus_monitor)
+        self.vibrance_consumer = VibranceFocusConsumer(self.settings, self.focus_monitor)
+
         self.settings_requested = False
         self.settings_window = None
-        self._focus_monitor_thread_id = None
 
         try:
             logger.info("Initializing monitor cache and setting brightness to 100%")
@@ -397,6 +386,18 @@ class QOLApp:
             self.settings.data["cs2_auto_accept_enabled"] = not self.settings.data.get("cs2_auto_accept_enabled", True)
             self.settings.save_settings()
 
+        def check_vibrance(_item):
+            return self.settings.data.get("vibrance_enabled", False)
+
+        def toggle_vibrance(_icon, _item):
+            self.settings.data["vibrance_enabled"] = not self.settings.data.get("vibrance_enabled", False)
+            self.settings.save_settings()
+            if not self.settings.data["vibrance_enabled"]:
+                vibrance_displays = self.settings.data.get("vibrance_displays", []) or None
+                set_vibrance(self.settings.data.get("vibrance_default_level", 50), vibrance_displays)
+            else:
+                self.focus_monitor.reset()
+
         def toggle_auto_lock(_icon, _item):
             self.settings.data["auto_lock_enabled"] = not self.settings.data.get("auto_lock_enabled", True)
             self.settings.save_settings()
@@ -414,24 +415,16 @@ class QOLApp:
             version_action = self._refresh_updates
             version_label = f"{PROGRAM_NAME} v{VERSION} ↻"
 
+        lol_submenu = pystray.Menu(
+            pystray.MenuItem("Auto Accept", toggle_auto_accept, checked=check_auto_accept),
+            pystray.MenuItem("Auto Pick", toggle_auto_pick, checked=check_auto_pick),
+            pystray.MenuItem("Auto Lock", toggle_auto_lock, checked=check_auto_lock),
+        )
+
         menu_items = [
             pystray.MenuItem(version_label, version_action),
             pystray.Menu.SEPARATOR,
-            pystray.MenuItem(
-                "LoL - Auto Accept",
-                toggle_auto_accept,
-                checked=check_auto_accept
-            ),
-            pystray.MenuItem(
-                "LoL - Auto Pick",
-                toggle_auto_pick,
-                checked=check_auto_pick
-            ),
-            pystray.MenuItem(
-                "LoL - Auto Lock",
-                toggle_auto_lock,
-                checked=check_auto_lock
-            ),
+            pystray.MenuItem("LoL", lol_submenu),
             pystray.MenuItem(
                 "CS2 - Auto Accept",
                 toggle_cs2_auto_accept,
@@ -441,6 +434,11 @@ class QOLApp:
                 "Dimming",
                 toggle_dimming,
                 checked=check_dimming
+            ),
+            pystray.MenuItem(
+                "Digital Vibrance",
+                toggle_vibrance,
+                checked=check_vibrance
             ),
             pystray.MenuItem("Auto Update", toggle_auto_update, checked=check_auto_update),
             pystray.MenuItem("Settings", self.show_settings),
@@ -465,12 +463,9 @@ class QOLApp:
                     pass
             self.lcu_connector.stop()
             self.cs2_watcher.stop()
-            # Stop the focus monitor thread by posting WM_QUIT to its message loop
-            if self._focus_monitor_thread_id:
-                WM_QUIT = 0x0012
-                ctypes.windll.user32.PostThreadMessageW(
-                    self._focus_monitor_thread_id, WM_QUIT, 0, 0
-                )
+            self.brightness_consumer.stop()
+            self.vibrance_consumer.stop()
+            self.focus_monitor.stop()
             self.icon.stop()
             if self.settings.data["dimming_enabled"]:
                 set_brightness_side_monitors(
@@ -484,7 +479,9 @@ class QOLApp:
     def run(self):
         self.lcu_connector.start()
         self.cs2_watcher.start()
-        Thread(target=self._focus_monitor_loop, daemon=True).start()
+        self.focus_monitor.start()
+        self.brightness_consumer.start()
+        self.vibrance_consumer.start()
         Thread(target=self._update_check_loop, daemon=True).start()
         Thread(target=self.icon.run, daemon=True).start()
         Thread(target=self._enable_dark_menus_when_ready, daemon=True).start()
@@ -511,88 +508,3 @@ class QOLApp:
                 return
             time.sleep(0.1)
         logger.debug("pystray HWNDs never appeared; skipping dark menu opt-in")
-
-    def _on_foreground_change(self, _win_event_hook_handle, _event_id: int,
-                                hwnd: wintypes.HWND, _id_object: wintypes.LONG,
-                                _id_child: wintypes.LONG, _event_thread_id: wintypes.DWORD,
-                                _event_time_ms: wintypes.DWORD):
-        """Callback for foreground window change events."""
-        try:
-            # Always get the actual foreground window, not the event's hwnd
-            # (EVENT_OBJECT_FOCUS can pass child controls, not top-level windows)
-            foreground_hwnd = ctypes.windll.user32.GetForegroundWindow()
-            if not foreground_hwnd:
-                return  # No foreground window - transient state
-            focused = get_window_title(foreground_hwnd)
-            # Skip transient windows (empty title, Alt+Tab switcher, etc.)
-            if not focused or focused in ('Task Switching', 'DesktopWindowXamlSource'):
-                return
-
-            if focused != self.last_focused_window:
-                self.last_focused_window = focused
-                logger.debug(f"Focus changed to: '{focused}'")
-
-                cleaned_focused = clean_window_title(focused)
-
-                if self.settings.data["dimming_enabled"]:
-                    games_list = self.settings.data['games_to_dimm']
-                    is_game_focused = cleaned_focused in games_list
-                    dim_all_mode = self.settings.data["dim_all_except_focused"]
-                    brightness_settings = self.settings.data["monitor_brightness"]
-
-                    if is_game_focused:
-                        monitors_to_dim = (get_all_monitor_serials_except_focused()
-                                           if dim_all_mode
-                                           else self.settings.data["dimmable_monitors"])
-                        logger.debug(f"Game focused - dimming monitors: {monitors_to_dim}")
-                        set_brightness_side_monitors(brightness_settings["low"], monitors_to_dim)
-                    else:
-                        logger.debug("Game unfocused - restoring all monitors")
-                        set_brightness_side_monitors(brightness_settings["high"], get_all_monitor_serials())
-
-                if self.settings.data.get("vibrance_enabled", False):
-                    vibrance_games = self.settings.data.get("games_vibrance", [])
-                    is_vibrance_game = cleaned_focused in vibrance_games
-                    vibrance_displays = self.settings.data.get("vibrance_displays", []) or None
-                    level = (self.settings.data.get("vibrance_game_level", 75)
-                             if is_vibrance_game
-                             else self.settings.data.get("vibrance_default_level", 50))
-                    logger.debug(f"Vibrance: {'game' if is_vibrance_game else 'default'} → {level}%")
-                    set_vibrance(level, vibrance_displays)
-        except Exception as e:
-            logger.error(f"Error in foreground change handler: {e}")
-
-    def _focus_monitor_loop(self):
-        """Run the Windows event hook message loop for focus monitoring."""
-        try:
-            self._focus_monitor_thread_id = ctypes.windll.kernel32.GetCurrentThreadId()
-            with init_com():
-                self._foreground_hook = set_win_event_hook(
-                    self._on_foreground_change,
-                    HookEvent.SYSTEM_FOREGROUND
-                )
-                self._minimize_end_hook = set_win_event_hook(
-                    self._on_foreground_change,
-                    HookEvent.SYSTEM_MINIMIZEEND
-                )
-                self._object_focus_hook = set_win_event_hook(
-                    self._on_foreground_change,
-                    HookEvent.OBJECT_FOCUS
-                )
-                self._switch_end_hook = set_win_event_hook(
-                    self._on_foreground_change,
-                    HookEvent.SYSTEM_SWITCHEND
-                )
-                logger.debug("Focus monitor hooks registered")
-                _run_message_loop()
-        except Exception as e:
-            logger.error(f"Error in focus monitor loop: {e}")
-        finally:
-            if hasattr(self, '_foreground_hook') and self._foreground_hook:
-                self._foreground_hook.unhook()
-            if hasattr(self, '_minimize_end_hook') and self._minimize_end_hook:
-                self._minimize_end_hook.unhook()
-            if hasattr(self, '_object_focus_hook') and self._object_focus_hook:
-                self._object_focus_hook.unhook()
-            if hasattr(self, '_switch_end_hook') and self._switch_end_hook:
-                self._switch_end_hook.unhook()

--- a/src/app.py
+++ b/src/app.py
@@ -44,6 +44,7 @@ from brightness import (
     set_brightness_side_monitors, get_all_monitor_serials_except_focused,
     clean_window_title, init_monitors_cache, get_all_monitor_serials
 )
+from vibrance import init_nvapi, set_vibrance
 from lol import LoLAutoAccept, LoLAutoPick, SharedLCUConnector
 from cs2 import CS2AutoAccept, CS2ConsoleWatcher
 from settings_window import SettingsWindow
@@ -152,6 +153,11 @@ class QOLApp:
             set_brightness_side_monitors(100, get_all_monitor_serials())
         except Exception as e:
             logger.error(f"Failed to initialize monitors on startup: {e}")
+
+        try:
+            init_nvapi()
+        except Exception as e:
+            logger.error(f"Failed to initialize NVAPI: {e}")
 
     def signal_handler(self, _signum, _frame):
         logger.debug("Received signal to terminate. Cleaning up...")
@@ -471,6 +477,9 @@ class QOLApp:
                     self.settings.data["monitor_brightness"]["high"],
                     self.settings.data["dimmable_monitors"]
                 )
+            if self.settings.data.get("vibrance_enabled", False):
+                vibrance_displays = self.settings.data.get("vibrance_displays", []) or None
+                set_vibrance(self.settings.data.get("vibrance_default_level", 50), vibrance_displays)
 
     def run(self):
         self.lcu_connector.start()
@@ -523,9 +532,10 @@ class QOLApp:
                 self.last_focused_window = focused
                 logger.debug(f"Focus changed to: '{focused}'")
 
+                cleaned_focused = clean_window_title(focused)
+
                 if self.settings.data["dimming_enabled"]:
                     games_list = self.settings.data['games_to_dimm']
-                    cleaned_focused = clean_window_title(focused)
                     is_game_focused = cleaned_focused in games_list
                     dim_all_mode = self.settings.data["dim_all_except_focused"]
                     brightness_settings = self.settings.data["monitor_brightness"]
@@ -539,6 +549,16 @@ class QOLApp:
                     else:
                         logger.debug("Game unfocused - restoring all monitors")
                         set_brightness_side_monitors(brightness_settings["high"], get_all_monitor_serials())
+
+                if self.settings.data.get("vibrance_enabled", False):
+                    vibrance_games = self.settings.data.get("games_vibrance", [])
+                    is_vibrance_game = cleaned_focused in vibrance_games
+                    vibrance_displays = self.settings.data.get("vibrance_displays", []) or None
+                    level = (self.settings.data.get("vibrance_game_level", 75)
+                             if is_vibrance_game
+                             else self.settings.data.get("vibrance_default_level", 50))
+                    logger.debug(f"Vibrance: {'game' if is_vibrance_game else 'default'} → {level}%")
+                    set_vibrance(level, vibrance_displays)
         except Exception as e:
             logger.error(f"Error in foreground change handler: {e}")
 

--- a/src/brightness.py
+++ b/src/brightness.py
@@ -1,6 +1,7 @@
 import re
 import logging
 import screen_brightness_control as sbc
+from threading import Thread
 from win32gui import GetForegroundWindow
 from win32api import GetMonitorInfo, MonitorFromWindow
 from win32con import MONITOR_DEFAULTTONEAREST
@@ -139,3 +140,57 @@ def get_all_monitor_serials_except_focused():
     except Exception as e:
         logger.error(f"Error getting non-focused monitors: {e}")
         return []
+
+
+class BrightnessFocusConsumer:
+    """Daemon thread that subscribes to a FocusMonitor and dims/restores
+    monitors when a tracked game gains/loses focus.
+
+    Owns its own thread so its (potentially slow) sbc calls don't delay
+    other focus consumers."""
+
+    def __init__(self, settings, focus_monitor):
+        self.settings = settings
+        self.focus_monitor = focus_monitor
+        self._thread = None
+        self._running = False
+
+    def start(self):
+        if self._running:
+            return
+        self._running = True
+        self._thread = Thread(target=self._run, daemon=True, name="brightness-focus")
+        self._thread.start()
+
+    def stop(self):
+        # FocusMonitor.stop() will notify_all and our wait() returns None.
+        self._running = False
+
+    def _run(self):
+        sub = self.focus_monitor.subscribe()
+        while self._running:
+            title = sub.wait()
+            if title is None:
+                return  # monitor stopped
+            try:
+                self._apply(title)
+            except Exception as e:
+                logger.error(f"Brightness consumer error: {e}")
+
+    def _apply(self, focused_title: str):
+        if not self.settings.data["dimming_enabled"]:
+            return
+        games_list = self.settings.data['games_to_dimm']
+        is_game_focused = focused_title in games_list
+        dim_all_mode = self.settings.data["dim_all_except_focused"]
+        brightness_settings = self.settings.data["monitor_brightness"]
+
+        if is_game_focused:
+            monitors_to_dim = (get_all_monitor_serials_except_focused()
+                               if dim_all_mode
+                               else self.settings.data["dimmable_monitors"])
+            logger.debug(f"Game focused - dimming monitors: {monitors_to_dim}")
+            set_brightness_side_monitors(brightness_settings["low"], monitors_to_dim)
+        else:
+            logger.debug("Game unfocused - restoring all monitors")
+            set_brightness_side_monitors(brightness_settings["high"], get_all_monitor_serials())

--- a/src/focus_monitor.py
+++ b/src/focus_monitor.py
@@ -1,0 +1,159 @@
+import ctypes
+import logging
+import threading
+from ctypes import wintypes
+from threading import Thread
+
+from win32_window_monitor import (
+    init_com, set_win_event_hook, get_window_title, HookEvent
+)
+
+from brightness import clean_window_title
+
+logger = logging.getLogger(__name__)
+
+
+def _run_message_loop():
+    """Run WIN32 message loop until WM_QUIT is received.
+
+    Workaround for win32-window-monitor bug using TranslateMessageW
+    which doesn't exist (should be TranslateMessage).
+    """
+    user32 = ctypes.windll.user32
+    msg = wintypes.MSG()
+    while user32.GetMessageW(ctypes.byref(msg), 0, 0, 0) != 0:
+        user32.TranslateMessage(ctypes.byref(msg))
+        user32.DispatchMessageW(ctypes.byref(msg))
+
+
+# Transient windows that briefly steal focus during alt-tab / desktop switching.
+# We ignore these so they don't trip per-feature dedup or restore "default" state.
+_TRANSIENT_TITLES = {'Task Switching', 'DesktopWindowXamlSource'}
+
+
+class FocusMonitor:
+    """Single daemon that watches Windows foreground/focus events and publishes
+    the current focused-window title.
+
+    Features don't register callbacks here — they call ``subscribe()`` and run
+    their own thread that blocks on ``Subscription.wait()``. Each feature
+    reacts to focus changes independently, so a slow consumer (e.g. a
+    blocking ``screen_brightness_control`` retry loop) can't delay others.
+    """
+
+    def __init__(self):
+        self._cond = threading.Condition()
+        self._latest = None       # last cleaned title published
+        self._raw_latest = None   # last raw title (for dedup)
+        self._version = 0         # bumped on every publish; subscribers track this
+        self._stopped = False
+
+        self._thread_id = None
+        self._hooks = []
+        self._thread = None
+        self._running = False
+
+    def subscribe(self):
+        """Return a Subscription handle. The subscriber is responsible for
+        calling ``wait()`` from its own thread."""
+        return Subscription(self)
+
+    def get_focused(self):
+        """Return the most recently published cleaned title (or None)."""
+        with self._cond:
+            return self._latest
+
+    def reset(self):
+        """Invalidate the dedup baseline so the next focus event publishes
+        even if the focused window hasn't actually changed. Call after a
+        settings save so consumers re-apply on the next focus change."""
+        with self._cond:
+            self._raw_latest = None
+
+    def start(self):
+        if self._running:
+            return
+        self._running = True
+        self._thread = Thread(target=self._loop, daemon=True, name="focus-monitor")
+        self._thread.start()
+        logger.info("Focus monitor thread started")
+
+    def stop(self):
+        if not self._running:
+            return
+        self._running = False
+        with self._cond:
+            self._stopped = True
+            self._cond.notify_all()  # wake all subscribers so they can exit
+        if self._thread_id:
+            WM_QUIT = 0x0012
+            ctypes.windll.user32.PostThreadMessageW(self._thread_id, WM_QUIT, 0, 0)
+
+    def _on_event(self, _hook_handle, _event_id, _hwnd, _id_object,
+                  _id_child, _event_thread_id, _event_time_ms):
+        try:
+            # Always read the current foreground window — EVENT_OBJECT_FOCUS can
+            # fire for child controls whose hwnd isn't a top-level window.
+            foreground_hwnd = ctypes.windll.user32.GetForegroundWindow()
+            if not foreground_hwnd:
+                return
+            focused = get_window_title(foreground_hwnd)
+            if not focused or focused in _TRANSIENT_TITLES:
+                return
+            with self._cond:
+                if focused == self._raw_latest:
+                    return
+                self._raw_latest = focused
+                self._latest = clean_window_title(focused)
+                self._version += 1
+                self._cond.notify_all()
+            logger.debug(f"Focus changed to: '{focused}'")
+        except Exception as e:
+            logger.error(f"Error in focus event: {e}")
+
+    def _loop(self):
+        try:
+            self._thread_id = ctypes.windll.kernel32.GetCurrentThreadId()
+            with init_com():
+                for event in (HookEvent.SYSTEM_FOREGROUND,
+                              HookEvent.SYSTEM_MINIMIZEEND,
+                              HookEvent.OBJECT_FOCUS,
+                              HookEvent.SYSTEM_SWITCHEND):
+                    self._hooks.append(set_win_event_hook(self._on_event, event))
+                logger.debug("Focus monitor hooks registered")
+                _run_message_loop()
+        except Exception as e:
+            logger.error(f"Error in focus monitor loop: {e}")
+        finally:
+            for hook in self._hooks:
+                if hook:
+                    try:
+                        hook.unhook()
+                    except Exception:
+                        pass
+            self._hooks.clear()
+
+
+class Subscription:
+    """Per-consumer cursor over the FocusMonitor's published state.
+
+    ``wait()`` blocks until the publisher's version moves past the
+    subscriber's local cursor (or the monitor stops). It returns the latest
+    cleaned title — intermediate updates that arrived while the subscriber
+    was busy are coalesced into "latest", so consumers naturally skip stale
+    work. Returns None when the monitor has been stopped.
+    """
+
+    def __init__(self, monitor: FocusMonitor):
+        self._monitor = monitor
+        self._last_seen_version = 0
+
+    def wait(self) -> str | None:
+        with self._monitor._cond:
+            while (self._last_seen_version == self._monitor._version
+                   and not self._monitor._stopped):
+                self._monitor._cond.wait()
+            if self._monitor._stopped:
+                return None
+            self._last_seen_version = self._monitor._version
+            return self._monitor._latest

--- a/src/settings.py
+++ b/src/settings.py
@@ -30,6 +30,11 @@ class Settings:
         "cs2_auto_accept_enabled": True,
         "auto_update_enabled": False,
         "dim_all_except_focused": False,
+        "vibrance_enabled": False,
+        "vibrance_game_level": 75,
+        "vibrance_default_level": 50,
+        "games_vibrance": [],
+        "vibrance_displays": [],
         "default_champions": {
             "top": {"primary": None, "secondary": None},
             "jungle": {"primary": None, "secondary": None},
@@ -56,6 +61,11 @@ class Settings:
                 if "games_to_dimm" in self.data:
                     self.data["games_to_dimm"] = sorted(
                         [clean_window_title(g) for g in self.data["games_to_dimm"] if clean_window_title(g)],
+                        key=str.lower
+                    )
+                if "games_vibrance" in self.data:
+                    self.data["games_vibrance"] = sorted(
+                        [clean_window_title(g) for g in self.data["games_vibrance"] if clean_window_title(g)],
                         key=str.lower
                     )
                 # Migrate old champion format (single ID) to new format (primary/secondary)

--- a/src/settings_window.py
+++ b/src/settings_window.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import logging
 import tkinter as tk
@@ -6,10 +7,11 @@ import win32gui
 import sv_ttk
 import darkdetect
 import pywinstyles
+from PIL import ImageTk
 
 from lol.lcu_api import LCUApi
 from brightness import clean_window_title, get_cached_monitors
-from vibrance import get_display_count
+from vibrance import get_displays
 
 logger = logging.getLogger(__name__)
 
@@ -197,9 +199,17 @@ class SettingsWindow:
         self.app = app
         self.root = tk.Tk()
         self.root.title("QOL Settings")
-        self.root.geometry("420x1000")
-        self.root.minsize(380, 1000)
-        self.root.maxsize(600, 1000)
+        self.root.geometry("880x600")  # provisional; resized to content below
+        # Reuse the tray PIL image so the title bar / taskbar show the QOL icon
+        # instead of Tk's default. Keep a reference on self to prevent the
+        # PhotoImage from being garbage collected (otherwise it goes blank).
+        icon_image = getattr(app, '_icon_image', None) if app else None
+        if icon_image is not None:
+            try:
+                self._icon_photo = ImageTk.PhotoImage(icon_image, master=self.root)
+                self.root.iconphoto(True, self._icon_photo)
+            except Exception as e:
+                logger.debug(f"Could not set settings window icon: {e}")
         sv_ttk.set_theme(darkdetect.theme())
         self.monitor_vars = {}
         self.games_list = sorted(self.settings.data["games_to_dimm"], key=str.lower)
@@ -213,6 +223,12 @@ class SettingsWindow:
         self.champion_vars = {}
 
         self.create_widgets()
+        # Resize to natural content height so the window ends just under the
+        # tallest column instead of hard-coding a value.
+        self.root.update_idletasks()
+        content_height = self.root.winfo_reqheight()
+        self.root.geometry(f"880x{content_height}")
+        self.root.minsize(820, content_height)
         apply_theme_to_titlebar(self.root)
         # Bind cleanup to window close to avoid tkinter threading issues
         self.root.protocol("WM_DELETE_WINDOW", self._on_close)
@@ -389,106 +405,105 @@ class SettingsWindow:
         main_container = ttk.Frame(self.root)
         main_container.pack(fill="both", expand=True, padx=15, pady=15)
 
-        # Monitors Frame
-        monitors_frame = ttk.LabelFrame(main_container, text="Dimmable Monitors", padding=10)
-        monitors_frame.pack(fill="x", pady=(0, 10))
+        # Two-column body
+        columns = ttk.Frame(main_container)
+        columns.pack(fill="both", expand=True)
 
+        left_col = ttk.Frame(columns)
+        left_col.pack(side="left", fill="both", expand=True, padx=(0, 8))
+
+        right_col = ttk.Frame(columns)
+        right_col.pack(side="left", fill="both", expand=True, padx=(8, 0))
+
+        # Dimming section (mirrors the Digital Vibrance layout below)
+        dimming_frame = ttk.LabelFrame(left_col, text="Dimming", padding=10)
+        dimming_frame.pack(fill="x", pady=(0, 10))
+
+        self.dimming_enabled_var = tk.BooleanVar(value=self.settings.data.get("dimming_enabled", True))
+        ttk.Checkbutton(
+            dimming_frame,
+            text="Enable dimming",
+            variable=self.dimming_enabled_var
+        ).pack(anchor="w", pady=(0, 5))
+
+        high_row = ttk.Frame(dimming_frame)
+        high_row.pack(fill="x", pady=(0, 2))
+        ttk.Label(high_row, text="Focused:").pack(side="left")
+        self.high_value_label = ttk.Label(high_row, text="100%", width=5)
+        self.high_value_label.pack(side="right")
+
+        self.high_brightness_var = tk.IntVar(value=self.settings.data["monitor_brightness"]["high"])
+        ttk.Scale(
+            dimming_frame,
+            from_=0, to=100,
+            orient="horizontal",
+            variable=self.high_brightness_var,
+            command=lambda v: self.high_value_label.config(text=f"{int(float(v))}%")
+        ).pack(fill="x")
+        self.high_value_label.config(text=f"{self.high_brightness_var.get()}%")
+
+        low_row = ttk.Frame(dimming_frame)
+        low_row.pack(fill="x", pady=(8, 2))
+        ttk.Label(low_row, text="Dimmed:").pack(side="left")
+        self.low_value_label = ttk.Label(low_row, text="10%", width=5)
+        self.low_value_label.pack(side="right")
+
+        self.low_brightness_var = tk.IntVar(value=self.settings.data["monitor_brightness"]["low"])
+        ttk.Scale(
+            dimming_frame,
+            from_=0, to=100,
+            orient="horizontal",
+            variable=self.low_brightness_var,
+            command=lambda v: self.low_value_label.config(text=f"{int(float(v))}%")
+        ).pack(fill="x")
+        self.low_value_label.config(text=f"{self.low_brightness_var.get()}%")
+
+        ttk.Label(dimming_frame, text="Apply to displays:").pack(anchor="w", pady=(8, 2))
         try:
             monitors_info = get_cached_monitors()
             logger.debug(f"Found {len(monitors_info)} monitors")
-
             for index, info in enumerate(monitors_info):
                 serial = info.get('serial', 'Unknown')
                 name = info.get('name', 'Unknown')
-                display_name = f"Monitor {index + 1}: {name}"
-
+                display_name = f"{index + 1}: {name}"
                 logger.debug(f"Adding monitor: {display_name}")
-
-                var = tk.BooleanVar()
-                var.set(serial in self.settings.data["dimmable_monitors"])
+                var = tk.BooleanVar(value=serial in self.settings.data["dimmable_monitors"])
                 self.monitor_vars[serial] = var
-
                 ttk.Checkbutton(
-                    monitors_frame,
+                    dimming_frame,
                     text=display_name,
                     variable=var
-                ).pack(anchor="w", pady=2)
-
+                ).pack(anchor="w", pady=1)
         except Exception as e:
             logger.error(f"Error setting up monitor checkboxes: {e}")
             ttk.Label(
-                monitors_frame,
+                dimming_frame,
                 text=f"Error loading monitors: {str(e)}",
                 foreground="red"
             ).pack(fill="x", pady=5)
 
-        # Brightness Frame
-        brightness_frame = ttk.LabelFrame(main_container, text="Brightness Settings", padding=10)
-        brightness_frame.pack(fill="x", pady=(0, 10))
+        ttk.Label(dimming_frame, text="Games (trigger dimming):").pack(anchor="w", pady=(8, 2))
 
-        high_frame = ttk.Frame(brightness_frame)
-        high_frame.pack(fill="x", pady=(0, 5))
-        ttk.Label(high_frame, text="Focused:").pack(side="left")
-        self.high_value_label = ttk.Label(high_frame, text="100%", width=5)
-        self.high_value_label.pack(side="right")
+        games_list_container = ttk.Frame(dimming_frame)
+        games_list_container.pack(fill="x")
 
-        self.high_brightness_var = tk.IntVar(value=self.settings.data["monitor_brightness"]["high"])
-        self.high_brightness = ttk.Scale(
-            brightness_frame,
-            from_=0,
-            to=100,
-            orient="horizontal",
-            variable=self.high_brightness_var,
-            command=lambda v: self.high_value_label.config(text=f"{int(float(v))}%")
+        games_scrollbar = ttk.Scrollbar(games_list_container)
+        games_scrollbar.pack(side="right", fill="y")
+
+        self.games_listbox = tk.Listbox(
+            games_list_container,
+            height=4,
+            selectmode="extended",
+            yscrollcommand=games_scrollbar.set,
         )
-        self.high_brightness.pack(fill="x")
-        self.high_value_label.config(text=f"{self.high_brightness_var.get()}%")
-
-        low_frame = ttk.Frame(brightness_frame)
-        low_frame.pack(fill="x", pady=(10, 5))
-        ttk.Label(low_frame, text="Dimmed:").pack(side="left")
-        self.low_value_label = ttk.Label(low_frame, text="10%", width=5)
-        self.low_value_label.pack(side="right")
-
-        self.low_brightness_var = tk.IntVar(value=self.settings.data["monitor_brightness"]["low"])
-        self.low_brightness = ttk.Scale(
-            brightness_frame,
-            from_=0,
-            to=100,
-            orient="horizontal",
-            variable=self.low_brightness_var,
-            command=lambda v: self.low_value_label.config(text=f"{int(float(v))}%")
-        )
-        self.low_brightness.pack(fill="x")
-        self.low_value_label.config(text=f"{self.low_brightness_var.get()}%")
-
-        self.dim_all_except_focused_var = tk.BooleanVar()
-        self.dim_all_except_focused_var.set(self.settings.data.get("dim_all_except_focused", False))
-        ttk.Checkbutton(
-            brightness_frame,
-            text="Dim all monitors except focused (experimental)",
-            variable=self.dim_all_except_focused_var
-        ).pack(anchor="w", pady=(10, 0))
-
-        # Games section
-        games_frame = ttk.LabelFrame(main_container, text="Games to Dim", padding=10)
-        games_frame.pack(fill="both", expand=True, pady=(0, 10))
-
-        list_container = ttk.Frame(games_frame)
-        list_container.pack(fill="both", expand=True)
-
-        scrollbar = ttk.Scrollbar(list_container)
-        scrollbar.pack(side="right", fill="y")
-
-        self.games_listbox = tk.Listbox(list_container, height=6, selectmode="extended", yscrollcommand=scrollbar.set)
-        self.games_listbox.pack(side="left", fill="both", expand=True)
-        scrollbar.config(command=self.games_listbox.yview)
+        self.games_listbox.pack(side="left", fill="x", expand=True)
+        games_scrollbar.config(command=self.games_listbox.yview)
 
         for game in self.games_list:
             self.games_listbox.insert(tk.END, game)
 
-        games_btn_frame = ttk.Frame(games_frame)
-        games_btn_frame.pack(fill="x", pady=(10, 0))
+        games_btn_frame = ttk.Frame(dimming_frame)
+        games_btn_frame.pack(fill="x", pady=(5, 0))
         ttk.Button(
             games_btn_frame,
             text="Add...",
@@ -502,8 +517,17 @@ class SettingsWindow:
             width=12
         ).pack(side="left", padx=(5, 0))
 
+        self.dim_all_except_focused_var = tk.BooleanVar(
+            value=self.settings.data.get("dim_all_except_focused", False)
+        )
+        ttk.Checkbutton(
+            dimming_frame,
+            text="Dim all monitors except focused (experimental)",
+            variable=self.dim_all_except_focused_var
+        ).pack(anchor="w", pady=(10, 0))
+
         # Digital Vibrance section
-        vibrance_frame = ttk.LabelFrame(main_container, text="Digital Vibrance (NVIDIA)", padding=10)
+        vibrance_frame = ttk.LabelFrame(right_col, text="Digital Vibrance (NVIDIA)", padding=10)
         vibrance_frame.pack(fill="x", pady=(0, 10))
 
         self.vibrance_enabled_var = tk.BooleanVar(value=self.settings.data.get("vibrance_enabled", False))
@@ -547,19 +571,27 @@ class SettingsWindow:
 
         # Per-display checkboxes
         try:
-            display_count = get_display_count()
+            nv_displays = get_displays()
         except Exception:
-            display_count = 0
+            nv_displays = []
 
-        if display_count > 0:
+        if nv_displays:
             ttk.Label(vibrance_frame, text="Apply to displays:").pack(anchor="w", pady=(8, 2))
             saved_displays = self.settings.data.get("vibrance_displays", [])
-            for i in range(display_count):
-                var = tk.BooleanVar(value=i in saved_displays)
-                self.vibrance_display_vars[i] = var
+            monitors_info = get_cached_monitors()
+            for nv_idx, gdi_name in nv_displays:
+                friendly = None
+                m = re.search(r'DISPLAY(\d+)', gdi_name or "")
+                if m:
+                    sbc_idx = int(m.group(1)) - 1
+                    if 0 <= sbc_idx < len(monitors_info):
+                        friendly = monitors_info[sbc_idx].get('name')
+                label = f"{nv_idx + 1}: {friendly}" if friendly else f"{nv_idx + 1}"
+                var = tk.BooleanVar(value=nv_idx in saved_displays)
+                self.vibrance_display_vars[nv_idx] = var
                 ttk.Checkbutton(
                     vibrance_frame,
-                    text=f"Display {i + 1}",
+                    text=label,
                     variable=var
                 ).pack(anchor="w", pady=1)
         else:
@@ -606,7 +638,7 @@ class SettingsWindow:
         ).pack(side="left", padx=(5, 0))
 
         # Champion selection section
-        champs_frame = ttk.LabelFrame(main_container, text="Default Champions per Role", padding=10)
+        champs_frame = ttk.LabelFrame(right_col, text="Default Champions per Role", padding=10)
         champs_frame.pack(fill="x", pady=(0, 10))
 
         if self.owned_champions:
@@ -671,7 +703,7 @@ class SettingsWindow:
             ).pack(anchor="w")
 
         # General section
-        general_frame = ttk.LabelFrame(main_container, text="General", padding=10)
+        general_frame = ttk.LabelFrame(left_col, text="General", padding=10)
         general_frame.pack(fill="x", pady=(0, 10))
 
         self.startup_var = tk.BooleanVar()
@@ -721,6 +753,7 @@ class SettingsWindow:
             logger.debug(f"Saved games_to_dimm: {self.settings.data['games_to_dimm']}")
 
             self.settings.data["dim_all_except_focused"] = self.dim_all_except_focused_var.get()
+            self.settings.data["dimming_enabled"] = self.dimming_enabled_var.get()
 
             self.settings.data["vibrance_enabled"] = self.vibrance_enabled_var.get()
             self.settings.data["vibrance_game_level"] = self.vibrance_game_var.get()
@@ -761,7 +794,7 @@ class SettingsWindow:
 
             self.settings.save_settings()
             if self.app:
-                self.app.last_focused_window = None
+                self.app.focus_monitor.reset()
             self._on_close()
         except Exception as e:
             logger.error(f"Error saving settings: {e}")
@@ -796,7 +829,8 @@ class SettingsWindow:
 
         # Neutralize other vars
         for attr in ('high_brightness_var', 'low_brightness_var',
-                     'dim_all_except_focused_var', 'startup_var',
+                     'dim_all_except_focused_var', 'dimming_enabled_var',
+                     'startup_var',
                      'vibrance_enabled_var', 'vibrance_game_var', 'vibrance_default_var'):
             var = getattr(self, attr, None)
             neutralize_var(var)

--- a/src/settings_window.py
+++ b/src/settings_window.py
@@ -9,6 +9,7 @@ import pywinstyles
 
 from lol.lcu_api import LCUApi
 from brightness import clean_window_title, get_cached_monitors
+from vibrance import get_display_count
 
 logger = logging.getLogger(__name__)
 
@@ -203,6 +204,9 @@ class SettingsWindow:
         self.monitor_vars = {}
         self.games_list = sorted(self.settings.data["games_to_dimm"], key=str.lower)
 
+        self.vibrance_games_list = sorted(self.settings.data.get("games_vibrance", []), key=str.lower)
+        self.vibrance_display_vars = {}
+
         self.lcu_api = LCUApi()
         self.owned_champions = self.lcu_api.get_owned_champions() if self.lcu_api.is_connected() else {}
         self.champion_id_to_name = {v: k for k, v in self.owned_champions.items()}
@@ -309,6 +313,77 @@ class SettingsWindow:
         for idx in selected:
             del self.games_list[idx]
         self.refresh_games_listbox()
+
+    def refresh_vibrance_games_listbox(self):
+        self.vibrance_games_listbox.delete(0, tk.END)
+        for game in self.vibrance_games_list:
+            self.vibrance_games_listbox.insert(tk.END, game)
+
+    def remove_selected_vibrance_games(self):
+        selected = list(self.vibrance_games_listbox.curselection())
+        selected.reverse()
+        for idx in selected:
+            del self.vibrance_games_list[idx]
+        self.refresh_vibrance_games_listbox()
+
+    def show_add_vibrance_game_dialog(self):
+        dialog = tk.Toplevel(self.root)
+        dialog.title("Add Game (Vibrance)")
+        dialog.geometry("400x450")
+        dialog.transient(self.root)
+        dialog.grab_set()
+        sv_ttk.set_theme(darkdetect.theme())
+        apply_theme_to_titlebar(dialog)
+
+        dialog.update_idletasks()
+        x = self.root.winfo_x() + (self.root.winfo_width() - 400) // 2
+        y = self.root.winfo_y() + (self.root.winfo_height() - 450) // 2
+        dialog.geometry(f"+{x}+{y}")
+
+        main_frame = ttk.Frame(dialog, padding=15)
+        main_frame.pack(fill="both", expand=True)
+
+        ttk.Label(main_frame, text="Select from running programs:").pack(anchor="w")
+
+        list_frame = ttk.Frame(main_frame)
+        list_frame.pack(fill="both", expand=True, pady=(5, 10))
+
+        scrollbar = ttk.Scrollbar(list_frame)
+        scrollbar.pack(side="right", fill="y")
+
+        programs_list = tk.Listbox(list_frame, height=15, yscrollcommand=scrollbar.set, selectmode="extended")
+        programs_list.pack(side="left", fill="both", expand=True)
+        scrollbar.config(command=programs_list.yview)
+
+        for program in self.get_running_programs():
+            programs_list.insert(tk.END, program)
+
+        ttk.Separator(main_frame, orient="horizontal").pack(fill="x", pady=10)
+        ttk.Label(main_frame, text="Or enter manually:").pack(anchor="w")
+        manual_entry = ttk.Entry(main_frame)
+        manual_entry.pack(fill="x", pady=(5, 10))
+
+        def add_selected():
+            added = False
+            for idx in programs_list.curselection():
+                game = clean_window_title(programs_list.get(idx))
+                if game and game not in self.vibrance_games_list:
+                    self.vibrance_games_list.append(game)
+                    added = True
+            manual = clean_window_title(manual_entry.get())
+            if manual and manual not in self.vibrance_games_list:
+                self.vibrance_games_list.append(manual)
+                added = True
+            if added:
+                self.vibrance_games_list.sort(key=str.lower)
+                self.refresh_vibrance_games_listbox()
+            dialog.destroy()
+
+        btn_frame = ttk.Frame(main_frame)
+        btn_frame.pack(fill="x")
+        ttk.Button(btn_frame, text="Cancel", command=dialog.destroy).pack(side="right", padx=(5, 0))
+        ttk.Button(btn_frame, text="Add Selected", command=add_selected).pack(side="right")
+        programs_list.bind('<Double-Button-1>', lambda e: add_selected())
 
     def create_widgets(self):
         main_container = ttk.Frame(self.root)
@@ -424,6 +499,109 @@ class SettingsWindow:
             games_btn_frame,
             text="Remove",
             command=self.remove_selected_games,
+            width=12
+        ).pack(side="left", padx=(5, 0))
+
+        # Digital Vibrance section
+        vibrance_frame = ttk.LabelFrame(main_container, text="Digital Vibrance (NVIDIA)", padding=10)
+        vibrance_frame.pack(fill="x", pady=(0, 10))
+
+        self.vibrance_enabled_var = tk.BooleanVar(value=self.settings.data.get("vibrance_enabled", False))
+        ttk.Checkbutton(
+            vibrance_frame,
+            text="Enable digital vibrance",
+            variable=self.vibrance_enabled_var
+        ).pack(anchor="w", pady=(0, 5))
+
+        game_vib_row = ttk.Frame(vibrance_frame)
+        game_vib_row.pack(fill="x", pady=(0, 2))
+        ttk.Label(game_vib_row, text="Game vibrance:").pack(side="left")
+        self.vibrance_game_label = ttk.Label(game_vib_row, text="75%", width=5)
+        self.vibrance_game_label.pack(side="right")
+
+        self.vibrance_game_var = tk.IntVar(value=self.settings.data.get("vibrance_game_level", 75))
+        ttk.Scale(
+            vibrance_frame,
+            from_=0, to=100,
+            orient="horizontal",
+            variable=self.vibrance_game_var,
+            command=lambda v: self.vibrance_game_label.config(text=f"{int(float(v))}%")
+        ).pack(fill="x")
+        self.vibrance_game_label.config(text=f"{self.vibrance_game_var.get()}%")
+
+        default_vib_row = ttk.Frame(vibrance_frame)
+        default_vib_row.pack(fill="x", pady=(8, 2))
+        ttk.Label(default_vib_row, text="Default vibrance:").pack(side="left")
+        self.vibrance_default_label = ttk.Label(default_vib_row, text="50%", width=5)
+        self.vibrance_default_label.pack(side="right")
+
+        self.vibrance_default_var = tk.IntVar(value=self.settings.data.get("vibrance_default_level", 50))
+        ttk.Scale(
+            vibrance_frame,
+            from_=0, to=100,
+            orient="horizontal",
+            variable=self.vibrance_default_var,
+            command=lambda v: self.vibrance_default_label.config(text=f"{int(float(v))}%")
+        ).pack(fill="x")
+        self.vibrance_default_label.config(text=f"{self.vibrance_default_var.get()}%")
+
+        # Per-display checkboxes
+        try:
+            display_count = get_display_count()
+        except Exception:
+            display_count = 0
+
+        if display_count > 0:
+            ttk.Label(vibrance_frame, text="Apply to displays:").pack(anchor="w", pady=(8, 2))
+            saved_displays = self.settings.data.get("vibrance_displays", [])
+            for i in range(display_count):
+                var = tk.BooleanVar(value=i in saved_displays)
+                self.vibrance_display_vars[i] = var
+                ttk.Checkbutton(
+                    vibrance_frame,
+                    text=f"Display {i + 1}",
+                    variable=var
+                ).pack(anchor="w", pady=1)
+        else:
+            ttk.Label(
+                vibrance_frame,
+                text="No NVIDIA displays detected",
+                foreground="gray"
+            ).pack(anchor="w", pady=(8, 0))
+
+        # Vibrance games list
+        ttk.Label(vibrance_frame, text="Games (trigger vibrance):").pack(anchor="w", pady=(8, 2))
+
+        vib_list_container = ttk.Frame(vibrance_frame)
+        vib_list_container.pack(fill="x")
+
+        vib_scrollbar = ttk.Scrollbar(vib_list_container)
+        vib_scrollbar.pack(side="right", fill="y")
+
+        self.vibrance_games_listbox = tk.Listbox(
+            vib_list_container,
+            height=4,
+            selectmode="extended",
+            yscrollcommand=vib_scrollbar.set
+        )
+        self.vibrance_games_listbox.pack(side="left", fill="x", expand=True)
+        vib_scrollbar.config(command=self.vibrance_games_listbox.yview)
+
+        for game in self.vibrance_games_list:
+            self.vibrance_games_listbox.insert(tk.END, game)
+
+        vib_btn_frame = ttk.Frame(vibrance_frame)
+        vib_btn_frame.pack(fill="x", pady=(5, 0))
+        ttk.Button(
+            vib_btn_frame,
+            text="Add...",
+            command=self.show_add_vibrance_game_dialog,
+            width=12
+        ).pack(side="left")
+        ttk.Button(
+            vib_btn_frame,
+            text="Remove",
+            command=self.remove_selected_vibrance_games,
             width=12
         ).pack(side="left", padx=(5, 0))
 
@@ -544,6 +722,17 @@ class SettingsWindow:
 
             self.settings.data["dim_all_except_focused"] = self.dim_all_except_focused_var.get()
 
+            self.settings.data["vibrance_enabled"] = self.vibrance_enabled_var.get()
+            self.settings.data["vibrance_game_level"] = self.vibrance_game_var.get()
+            self.settings.data["vibrance_default_level"] = self.vibrance_default_var.get()
+            self.settings.data["vibrance_displays"] = [
+                i for i, var in self.vibrance_display_vars.items() if var.get()
+            ]
+            self.settings.data["games_vibrance"] = sorted(
+                [clean_window_title(g) for g in self.vibrance_games_list if clean_window_title(g)],
+                key=str.lower
+            )
+
             if self.champion_vars:
                 default_champions = {}
                 for role_key, vars_dict in self.champion_vars.items():
@@ -600,9 +789,15 @@ class SettingsWindow:
             role_vars.clear()
         self.champion_vars.clear()
 
+        # Neutralize vibrance display vars
+        for var in self.vibrance_display_vars.values():
+            neutralize_var(var)
+        self.vibrance_display_vars.clear()
+
         # Neutralize other vars
         for attr in ('high_brightness_var', 'low_brightness_var',
-                     'dim_all_except_focused_var', 'startup_var'):
+                     'dim_all_except_focused_var', 'startup_var',
+                     'vibrance_enabled_var', 'vibrance_game_var', 'vibrance_default_var'):
             var = getattr(self, attr, None)
             neutralize_var(var)
             setattr(self, attr, None)

--- a/src/vibrance.py
+++ b/src/vibrance.py
@@ -1,5 +1,6 @@
 import ctypes
 import logging
+from threading import Thread
 
 logger = logging.getLogger(__name__)
 
@@ -8,6 +9,7 @@ _NVAPI_INITIALIZE = 0x0150E828
 _NVAPI_ENUM_DISPLAY_HANDLE = 0x9ABDD40D
 _NVAPI_GET_DVC_INFO = 0x4085DE45
 _NVAPI_SET_DVC_LEVEL = 0x172409B4
+_NVAPI_GET_ASSOC_DISPLAY_NAME = 0x22A78B05
 
 _MAX_DISPLAYS = 16
 
@@ -94,6 +96,35 @@ def get_display_count() -> int:
     return len(_display_handles)
 
 
+def get_displays() -> list[tuple[int, str]]:
+    """Return [(nvapi_index, gdi_name), ...] for each NVIDIA-attached display.
+
+    gdi_name is the Windows GDI device path like '\\\\.\\DISPLAY1', or '' if
+    the lookup failed."""
+    if not _initialized and not init_nvapi():
+        return []
+
+    get_name_fn = _query(
+        _NVAPI_GET_ASSOC_DISPLAY_NAME,
+        ctypes.c_int32,
+        ctypes.c_void_p,
+        ctypes.c_char * 64,
+    )
+
+    out = []
+    for i, handle in enumerate(_display_handles):
+        gdi_name = ""
+        if get_name_fn:
+            buf = (ctypes.c_char * 64)()
+            try:
+                if get_name_fn(handle, buf) == 0:
+                    gdi_name = buf.value.decode('ascii', errors='ignore')
+            except Exception as e:
+                logger.debug(f"GetAssociatedNvidiaDisplayName failed for {i}: {e}")
+        out.append((i, gdi_name))
+    return out
+
+
 def _get_dvc_info(display_index: int):
     """Return (currentLevel, minLevel, maxLevel) or None."""
     if display_index >= len(_display_handles):
@@ -153,3 +184,48 @@ def set_vibrance(level_percent: int, display_indices: list | None = None) -> boo
         else:
             logger.debug(f"Display {idx}: DVC → {target} ({level_percent}%)")
     return ok
+
+
+class VibranceFocusConsumer:
+    """Daemon thread that subscribes to a FocusMonitor and switches NVIDIA
+    digital vibrance between 'game' and 'default' levels based on the
+    foreground window."""
+
+    def __init__(self, settings, focus_monitor):
+        self.settings = settings
+        self.focus_monitor = focus_monitor
+        self._thread = None
+        self._running = False
+
+    def start(self):
+        if self._running:
+            return
+        self._running = True
+        self._thread = Thread(target=self._run, daemon=True, name="vibrance-focus")
+        self._thread.start()
+
+    def stop(self):
+        self._running = False
+
+    def _run(self):
+        sub = self.focus_monitor.subscribe()
+        while self._running:
+            title = sub.wait()
+            if title is None:
+                return
+            try:
+                self._apply(title)
+            except Exception as e:
+                logger.error(f"Vibrance consumer error: {e}")
+
+    def _apply(self, focused_title: str):
+        if not self.settings.data.get("vibrance_enabled", False):
+            return
+        vibrance_games = self.settings.data.get("games_vibrance", [])
+        is_vibrance_game = focused_title in vibrance_games
+        vibrance_displays = self.settings.data.get("vibrance_displays", []) or None
+        level = (self.settings.data.get("vibrance_game_level", 75)
+                 if is_vibrance_game
+                 else self.settings.data.get("vibrance_default_level", 50))
+        logger.debug(f"Vibrance: {'game' if is_vibrance_game else 'default'} → {level}%")
+        set_vibrance(level, vibrance_displays)

--- a/src/vibrance.py
+++ b/src/vibrance.py
@@ -1,0 +1,155 @@
+import ctypes
+import logging
+
+logger = logging.getLogger(__name__)
+
+# NVAPI function IDs
+_NVAPI_INITIALIZE = 0x0150E828
+_NVAPI_ENUM_DISPLAY_HANDLE = 0x9ABDD40D
+_NVAPI_GET_DVC_INFO = 0x4085DE45
+_NVAPI_SET_DVC_LEVEL = 0x172409B4
+
+_MAX_DISPLAYS = 16
+
+_nvapi = None
+_query_interface = None
+_display_handles: list = []
+_initialized = False
+
+
+class _NvDVCInfo(ctypes.Structure):
+    _fields_ = [
+        ("version",       ctypes.c_uint32),
+        ("currentLevel",  ctypes.c_int32),
+        ("minLevel",      ctypes.c_int32),
+        ("maxLevel",      ctypes.c_int32),
+    ]
+
+
+def _query(func_id, restype, *argtypes):
+    """Return a ctypes callable for an NVAPI function ID, or None."""
+    ptr = _query_interface(func_id)
+    if not ptr:
+        return None
+    return ctypes.CFUNCTYPE(restype, *argtypes)(ptr)
+
+
+def init_nvapi() -> bool:
+    """Load NVAPI and enumerate display handles. Returns True on success."""
+    global _nvapi, _query_interface, _display_handles, _initialized
+
+    if _initialized:
+        return True
+
+    for dll_name in ("nvapi64.dll", "nvapi.dll"):
+        try:
+            _nvapi = ctypes.WinDLL(dll_name)
+            break
+        except OSError:
+            continue
+    else:
+        logger.warning("NVAPI not found — NVIDIA drivers not installed or no NVIDIA GPU")
+        return False
+
+    try:
+        _query_interface = _nvapi.nvapi_QueryInterface
+        _query_interface.restype = ctypes.c_void_p
+        _query_interface.argtypes = [ctypes.c_uint32]
+    except AttributeError:
+        logger.error("nvapi_QueryInterface not found")
+        return False
+
+    init_fn = _query(_NVAPI_INITIALIZE, ctypes.c_int32)
+    if not init_fn or init_fn() != 0:
+        logger.error("NvAPI_Initialize failed")
+        return False
+
+    enum_fn = _query(
+        _NVAPI_ENUM_DISPLAY_HANDLE,
+        ctypes.c_int32,
+        ctypes.c_uint32,
+        ctypes.POINTER(ctypes.c_void_p),
+    )
+    if not enum_fn:
+        logger.error("NvAPI_EnumNvidiaDisplayHandle not found")
+        return False
+
+    _display_handles = []
+    for i in range(_MAX_DISPLAYS):
+        handle = ctypes.c_void_p()
+        status = enum_fn(i, ctypes.byref(handle))
+        if status != 0:
+            break
+        if handle.value:
+            _display_handles.append(handle.value)
+
+    logger.info(f"NVAPI ready — {len(_display_handles)} display(s) found")
+    _initialized = True
+    return True
+
+
+def get_display_count() -> int:
+    if not _initialized:
+        init_nvapi()
+    return len(_display_handles)
+
+
+def _get_dvc_info(display_index: int):
+    """Return (currentLevel, minLevel, maxLevel) or None."""
+    if display_index >= len(_display_handles):
+        return None
+    get_fn = _query(
+        _NVAPI_GET_DVC_INFO,
+        ctypes.c_int32,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.POINTER(_NvDVCInfo),
+    )
+    if not get_fn:
+        return None
+
+    info = _NvDVCInfo()
+    info.version = ctypes.sizeof(_NvDVCInfo) | (1 << 16)
+    if get_fn(_display_handles[display_index], 0, ctypes.byref(info)) != 0:
+        return None
+    return info.currentLevel, info.minLevel, info.maxLevel
+
+
+def set_vibrance(level_percent: int, display_indices: list | None = None) -> bool:
+    """
+    Set digital vibrance for the given display indices.
+
+    level_percent: 0-100.  50 = driver default (maps to 0 in the ±1024 range).
+    display_indices: list of NVAPI display indices (0-based).  None = all displays.
+    """
+    if not _initialized and not init_nvapi():
+        return False
+
+    if display_indices is None:
+        display_indices = list(range(len(_display_handles)))
+
+    set_fn = _query(
+        _NVAPI_SET_DVC_LEVEL,
+        ctypes.c_int32,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.c_int32,
+    )
+    if not set_fn:
+        return False
+
+    ok = True
+    for idx in display_indices:
+        dvc = _get_dvc_info(idx)
+        if dvc is None:
+            ok = False
+            continue
+        _, min_lvl, max_lvl = dvc
+        target = int(min_lvl + (max_lvl - min_lvl) * level_percent / 100)
+        status = set_fn(_display_handles[idx], 0, target)
+        if status != 0:
+            logger.error(f"NvAPI_SetDVCLevel failed for display {idx}: {status}")
+            ok = False
+        else:
+            logger.debug(f"Display {idx}: DVC → {target} ({level_percent}%)")
+    return ok


### PR DESCRIPTION
## Summary

- Adds automatic digital vibrance control for NVIDIA displays via NVAPI (Windows only)
- Vibrance level increases when a game from a configurable list is focused, and returns to a default level on unfocus
- Per-monitor targeting: select which displays to apply vibrance to
- Separate game list for vibrance triggers, independent from the existing dimming game list
- New settings UI section with enable toggle, game-level and default-level sliders, per-display checkboxes, and game list management

## Details

- `src/vibrance.py`: new module wrapping NVAPI via ctypes — handles init, display enumeration, DVC info query, and level setting (0–100% mapped to the driver min/max range)
- `src/app.py`: initialises NVAPI on startup; applies vibrance on focus change alongside existing brightness logic
- `src/settings.py`: new default keys (`vibrance_enabled`, `vibrance_game_level`, `vibrance_default_level`, `games_vibrance`, `vibrance_displays`) with normalisation on load
- `src/settings_window.py`: vibrance section in the settings UI with sliders, per-display checkboxes, and an add/remove game list

## Requirements

- NVIDIA GPU with drivers that expose `nvapi64.dll` / `nvapi.dll`
- No additional Python dependencies (uses `ctypes`)